### PR TITLE
Refactor Line to not use “active” flag

### DIFF
--- a/scully.metex.config.ts
+++ b/scully.metex.config.ts
@@ -65,14 +65,14 @@ export const config: ScullyConfig = {
 		'/lines/:slug': {
 			type: 'json',
 			slug: {
-				url: `${process.env.API_URL}/lines?_where[active]=true`,
+				url: `${process.env.API_URL}/lines`,
 				property: 'slug'
 			}
 		},
 		'/lines/:lineSlug/:stationSlug': {
 			type: 'json',
 			lineSlug: {
-				url: `${process.env.API_URL}/lines?_where[active]=true`,
+				url: `${process.env.API_URL}/lines`,
 				property: 'slug'
 			},
 			stationSlug: {

--- a/src/app/fixtures/lines.fixtures.ts
+++ b/src/app/fixtures/lines.fixtures.ts
@@ -7,7 +7,6 @@ export const lineFactory = Factory.Sync.makeFactory<Line>({
 	id: Factory.each(i => `${i}`),
 	name: Factory.each(i => `${i}`),
 	description: Factory.each(i => `Sample description ${i}`),
-	active: true,
 	slug: Factory.each(i => `line-${i}`),
 	order: Factory.each(i => i),
 	created_at: Date.now().toString(),

--- a/src/app/fixtures/stations.fixtures.ts
+++ b/src/app/fixtures/stations.fixtures.ts
@@ -8,7 +8,6 @@ export const stationFactory = Factory.Sync.makeFactory<Station>({
 	id: Factory.each(i => `${i}`),
 	name: Factory.each(i => `Sample station ${i}`),
 	description: Factory.each(i => `Sample description ${i}`),
-	active: true,
 	slug: Factory.each(i => `station-${i}`),
 	line: lineFactory.build(),
 	created_at: Date.now().toString(),

--- a/src/app/graphql/lines.graphql
+++ b/src/app/graphql/lines.graphql
@@ -1,5 +1,5 @@
 query Lines {
-	lines(where: { active: true }, sort: "order:asc") {
+	lines(sort: "order:asc") {
 		id,
 		name,
 		slug,


### PR DESCRIPTION
Removes the "active" flag from the Lines API request since the API now uses publishing status to determine which Lines, Places, and Stations to show.

Closes #10